### PR TITLE
Add diagonal distances to wasserplan

### DIFF
--- a/wasserplan.py
+++ b/wasserplan.py
@@ -200,7 +200,6 @@ class Chain:
                                          self.district_ordering)
             diff = left_indicator != right_indicator
             districts_changed = np.where(diff.any(axis=1))[0].tolist()
-            print(districts_changed)
             distances = np.zeros((2, 2))
             for outer_idx, outer_district in enumerate(districts_changed):
                 for inner_idx, inner_district in enumerate(districts_changed):

--- a/wasserplan.py
+++ b/wasserplan.py
@@ -1,10 +1,11 @@
 """Wasserstein distances between districting plans."""
-import networkx as nx
-import cvxpy as cp
 import numpy as np
-from networkx.linalg.graphmatrix import incidence_matrix
-from scipy.optimize import linear_sum_assignment
+import cvxpy as cp
+import networkx as nx
+from typing import List, Dict
 from gerrychain import Partition
+from scipy.optimize import linear_sum_assignment
+from networkx.linalg.graphmatrix import incidence_matrix
 
 
 class Pair:
@@ -25,16 +26,12 @@ class Pair:
         :param pop_col: The name of the attribute specifying a node's
             population. Required for the "population" indicator only.
         """
-        #if not nx.algorithms.isomorphism.is_isomorphic(partition_a.graph,
-        #                                               partition_b.graph):
-        #    raise IsomorphismError('The graphs of the partitions are not '
-        #                           'isomorphic. Were the partitions '
-        #                           'generated from the same Markov chain?')
+        # TODO: (efficiently) verify isomorphism?
         if indicator == 'population' and not pop_col:
             raise EmbeddingError('Cannot generate population-based indicators '
                                  'without population data. Specify a '
                                  'population column.')
-        elif indicator not in ('population', 'node'):
+        if indicator not in ('population', 'node'):
             raise EmbeddingError(f'Unknown indicator type "{indicator}"!')
 
         self.indicator_type = indicator
@@ -49,7 +46,7 @@ class Pair:
         # 0..len(graph.nodes) - 1. We sort the nodes first in the hope that
         # doing so will result in a more easily interpretable ordering.
         # (For instance, on a 2x2 grid graph, we might expect the node
-        #  with NetworkX label (0, 0) to map to 0 and (1, 1) to map to 4.)
+        #  with NetworkX label (0, 0) to map to 0 and (1, 1) to map to 3.)
         self.node_ordering = {
             node: idx
             for idx, node in enumerate(sorted(partition_a.graph.nodes))
@@ -63,43 +60,15 @@ class Pair:
             for idx, district in enumerate(sorted(partition_a.parts.keys()))
         }
 
-        self._a_indicators = self.indicators(partition_a)
-        self._b_indicators = self.indicators(partition_b)
+        self._a_indicators = indicators(partition_a, indicator, pop_col,
+                                        self.node_ordering,
+                                        self.district_ordering)
+        self._b_indicators = indicators(partition_b, indicator, pop_col,
+                                        self.node_ordering,
+                                        self.district_ordering)
         self._pairwise_distances = None  # lazy-loaded
         self._edge_incidence = None  # lazy-loaded
         self._assignment = None  # lazy-loaded
-
-    def indicators(self, partition: Partition) -> np.ndarray:
-        """Generates indicator vectors for all districts in a partition."
-
-        :param partition: The partition to generate indicator vectors for.
-        """
-        n_districts = len(partition)
-        n_nodes = len(partition.graph.nodes)
-        indicator = np.zeros((n_districts, n_nodes))
-        if self.indicator_type == 'node':
-            for district_label, district_idx in self.district_ordering.items():
-                nodes_in_district = [
-                    self.node_ordering[node]
-                    for node in partition.parts[district_label]
-                ]
-                indicator[district_idx][nodes_in_district] = 1
-        elif self.indicator_type == 'population':
-            for district_label, district_idx in self.district_ordering.items():
-                for node_label in partition.parts[district_label]:
-                    node = partition.graph.nodes[node_label]
-                    try:
-                        node_pop = node[self.pop_col]
-                    except KeyError:
-                        raise EmbeddingError('Cannot create population '
-                                             f'indicator. Node {node_label} '
-                                             f'has no "{self.pop_col}" '
-                                             'attribute.')
-                    node_idx = self.node_ordering[node_label]
-                    indicator[district_idx][node_idx] = node_pop
-
-        # Norm so that rows sum to 1.
-        return indicator / np.sum(indicator, axis=1).reshape(-1, 1)
 
     def district_distance(self, a_label, b_label) -> np.float64:
         """Calculates the 1-Wasserstein distance between districts.
@@ -121,17 +90,9 @@ class Pair:
         if self._edge_incidence is None:
             self._edge_incidence = incidence_matrix(self.partition_a.graph,
                                                     oriented=True)
-
-        n_edges = len(self.partition_a.graph.edges)
-        edge_weights = cp.Variable(n_edges)
-        a_indicator = self._a_indicators[a_idx]
-        b_indicator = self._b_indicators[b_idx]
-        diff = b_indicator - a_indicator
-        objective = cp.Minimize(cp.sum(cp.abs(edge_weights)))
-        conservation = (self._edge_incidence @ edge_weights) == diff
-        prob = cp.Problem(objective, [conservation])
-        prob.solve(solver='ECOS')  # solver recommended by Zach for big graphs
-        return np.sum(np.abs(edge_weights.value))
+        return district_distance(self._a_indicators[a_idx],
+                                 self._b_indicators[b_idx],
+                                 self._edge_incidence)
 
     @property
     def distance(self) -> np.float64:
@@ -165,6 +126,151 @@ class Pair:
                 dist = self.district_distance(a_label, b_label)
                 distances[a_idx][b_idx] = dist
         return distances
+
+
+class Chain:
+    """A wrapper for statistics over a sequence of districting plans."""
+
+    def __init__(self,
+                 partitions: List[Partition],
+                 indicator: str = 'node',
+                 pop_col: str = None):
+        """
+        :param partitions: A list of :class:`gerrychain.Partition` objects
+            with the same underlying graph to comprae.
+        :param indicator: The name of the district indicator scheme to use.
+            Valid indicators are "node" (equal population assumed for
+            all nodes in the dual graph) and "population" (nodes are weighted
+            proportional to population).
+        :param pop_col: The name of the attribute specifying a node's
+            population. Required for the "population" indicator only.
+        """
+        if indicator == 'population' and not pop_col:
+            raise EmbeddingError('Cannot generate population-based indicators '
+                                 'without population data. Specify a '
+                                 'population column.')
+        if indicator not in ('population', 'node'):
+            raise EmbeddingError(f'Unknown indicator type "{indicator}"!')
+
+        self.partitions = partitions
+        self.indicator_type = indicator
+        self.pop_col = pop_col
+
+        self.node_ordering = {
+            node: idx
+            for idx, node in enumerate(sorted(partitions[0].graph.nodes))
+        }
+        self.district_ordering = {
+            district: idx
+            for idx, district in enumerate(sorted(partitions[1].parts.keys()))
+        }
+        self._edge_incidence = None  # lazy-loaded
+        self._diag_distances = None  # lazy-loaded
+
+    @property
+    def diag_distances(self):
+        """Calculates the 1-Wasserstein distances between adjacent plans.
+
+        This algorithm only works for ReCom and block/chuink flip. (These are
+        our most commonly used proposals.) We have shown that, for a ReCom-like
+        proposal where only two districts are changed at a time, there exists
+        an optimal matching between plans such that the labeling of unmodified
+        districts is untouched.
+        """
+        if self._diag_distances is not None:
+            return self._diag_distances
+        if self._edge_incidence is None:
+            self._edge_incidence = incidence_matrix(self.partitions[0].graph,
+                                                    oriented=True)
+
+        diag_distances = np.zeros(len(self.partitions) - 1)
+        left_indicator = None
+        right_indicator = indicators(self.partitions[0], self.indicator_type,
+                                     self.pop_col, self.node_ordering,
+                                     self.district_ordering)
+
+        for part_idx in range(len(self.partitions) - 1):
+            # Indices returned by np.where() correspond directly to the
+            # indices of the indicator vectors; note that they do *not*
+            # necessarily relate to district labels.
+            left_indicator = right_indicator
+            right_indicator = indicators(self.partitions[part_idx + 1],
+                                         self.indicator_type, self.pop_col,
+                                         self.node_ordering,
+                                         self.district_ordering)
+            diff = left_indicator != right_indicator
+            districts_changed = np.where(diff.any(axis=1))[0].tolist()
+            print(districts_changed)
+            distances = np.zeros((2, 2))
+            for outer_idx, outer_district in enumerate(districts_changed):
+                for inner_idx, inner_district in enumerate(districts_changed):
+                    dist = district_distance(left_indicator[outer_district],
+                                             right_indicator[inner_district],
+                                             self._edge_incidence)
+                    distances[outer_idx][inner_idx] = dist
+            matched_distance = distances[0][0] + distances[1][1]
+            swapped_distance = distances[0][1] + distances[1][0]
+            diag_distances[part_idx] = min(matched_distance, swapped_distance)
+        self._diag_distances = diag_distances
+        return diag_distances
+
+
+def district_distance(a_indicator: np.ndarray, b_indicator: np.ndarray,
+                      edge_incidence: np.ndarray) -> np.float64:
+    """Calculates the 1-Wasserstein distance between two districts.
+
+    :param a_indicator: The indicator vector of one district.
+    :param b_indicator: The indicator vector of the other district.
+    :param edge_incidence: The edge incidence matrix for the districts'
+        underlying graph.
+    """
+    n_edges = edge_incidence.shape[1]
+    edge_weights = cp.Variable(n_edges)
+    diff = b_indicator - a_indicator
+    objective = cp.Minimize(cp.sum(cp.abs(edge_weights)))
+    conservation = (edge_incidence @ edge_weights) == diff
+    prob = cp.Problem(objective, [conservation])
+    prob.solve(solver='ECOS')  # solver recommended by Zach for big graphs
+    return np.sum(np.abs(edge_weights.value))
+
+
+def indicators(partition: Partition, indicator_type: str, pop_col: str,
+               node_ordering: Dict, district_ordering: Dict) -> np.ndarray:
+    """Generates indicator vectors for all districts in a partition."
+
+    :param partition: The partition to generate indicator vectors for.
+    :param indicator_type: The type of indicator to use.
+    :param pop_col: The node attribute with population counts.
+    :param node_ordering: A dictionary mapping NetworkX node labels to
+        indicator matrix column indices.
+    :param district_ordering: A dictionary mapping district labels to
+        indicator matrix row indices.
+    :returns: A matrix of indicator vectors (# of districts X # of nodes).
+    """
+    n_districts = len(partition)
+    n_nodes = len(partition.graph.nodes)
+    indicator = np.zeros((n_districts, n_nodes))
+    if indicator_type == 'node':
+        for district_label, district_idx in district_ordering.items():
+            nodes_in_district = [
+                node_ordering[node] for node in partition.parts[district_label]
+            ]
+            indicator[district_idx][nodes_in_district] = 1
+    elif indicator_type == 'population':
+        for district_label, district_idx in district_ordering.items():
+            for node_label in partition.parts[district_label]:
+                node = partition.graph.nodes[node_label]
+                try:
+                    node_pop = node[pop_col]
+                except KeyError:
+                    raise EmbeddingError('Cannot create population '
+                                         f'indicator. Node {node_label} '
+                                         f'has no "{pop_col}" attribute.')
+                node_idx = node_ordering[node_label]
+                indicator[district_idx][node_idx] = node_pop
+
+    # Norm so that rows sum to 1.
+    return indicator / np.sum(indicator, axis=1).reshape(-1, 1)
 
 
 class EmbeddingError(Exception):


### PR DESCRIPTION
We have shown that, for a ReCom-like proposal where only two districts are changed at a time, there exists an optimal matching between plans such that the labeling of unmodified districts is untouched. This allows for the efficient computation of distances between plans on the "chain diagonal" (chain step 0 → step 1, step 1 → step 2, ...) We think that computing statistics on these diagonal distances may be interesting. **This PR adds a `Chain` class for computing diagonal distances and moves some shared functionality between `Chain` and `Pair` into more generic functions outside of the two classes.**